### PR TITLE
Fixed the application launcher location patching on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+#JetBrains .idea folder
+.idea/

--- a/cleaner.py
+++ b/cleaner.py
@@ -57,15 +57,23 @@ try:
             f' * {os.path.join(filepath, "app.asar.bak")} was not found: step skipped.')
 
     if sys.platform == 'linux' and 'microsoft' not in platform.uname()[3].lower():
-        bin_path = '/usr/bin/notion-app' if os.path.exists(
-            '/usr/bin/notion-app') else '/usr/bin/notion'
-        with open(bin_path, 'r', encoding='UTF-8') as launcher:
-            if 'app.asar' not in launcher:
+        path = ''
+        if os.path.exists('/opt/notion-app/notion-app'):
+            path = '/opt/notion-app/notion-app'
+        elif os.path.exists('/usr/bin/notion-app'):
+            path = '/usr/bin/notion-app'
+        elif os.path.exists('/usr/bin/notion'):
+            path = '/usr/bin/notion'
+        else:
+            raise ValueError("Couldn't find the app launcher")
+        with open(path, 'r', encoding='UTF-8') as launcher:
+            contents = launcher.read()
+            if 'app.asar' not in contents:
                 print(
                     f' ...patching app launcher')
                 subprocess.call(
-                    ['sed', '-i', r's/electron\ app/electron\ app\.asar/',
-                     bin_path])
+                    ['sed', '-i', r's/electron6\ app/electron6\ app\.asar/',
+                     path])
 
     print(f'\n{bold}>>> SUCCESSFULLY CLEANED <<<{normal}')
 

--- a/cleaner.py
+++ b/cleaner.py
@@ -1,4 +1,3 @@
-
 # notion-enhancer
 # (c) 2020 dragonwocky <thedragonring.bod@gmail.com>
 # (c) 2020 TarasokUA
@@ -25,12 +24,12 @@ try:
     filepath = ''
     if 'microsoft' in platform.uname()[3].lower() and sys.platform == 'linux':
         filepath = '/mnt/c/' + \
-            subprocess.run(
-                ['cmd.exe', '/c', 'echo', '%localappdata%'], stdout=subprocess.PIPE).stdout \
-            .rstrip().decode('utf-8')[3:].replace('\\', '/') + '/Programs/Notion/resources'
+                   subprocess.run(
+                       ['cmd.exe', '/c', 'echo', '%localappdata%'], stdout=subprocess.PIPE).stdout \
+                       .rstrip().decode('utf-8')[3:].replace('\\', '/') + '/Programs/Notion/resources'
     elif sys.platform == 'win32':
         filepath = subprocess.run(['echo', '%localappdata%'], shell=True, capture_output=True).stdout \
-            .rstrip().decode('utf-8') + '\\Programs\\Notion\\resources'
+                       .rstrip().decode('utf-8') + '\\Programs\\Notion\\resources'
     elif sys.platform == 'linux':
         filepath = '/opt/notion-app' if os.path.exists(
             '/opt/notion-app') else '/opt/notion'
@@ -57,23 +56,15 @@ try:
             f' * {os.path.join(filepath, "app.asar.bak")} was not found: step skipped.')
 
     if sys.platform == 'linux' and 'microsoft' not in platform.uname()[3].lower():
-        path = ''
-        if os.path.exists('/opt/notion-app/notion-app'):
-            path = '/opt/notion-app/notion-app'
-        elif os.path.exists('/usr/bin/notion-app'):
-            path = '/usr/bin/notion-app'
-        elif os.path.exists('/usr/bin/notion'):
-            path = '/usr/bin/notion'
-        else:
-            raise ValueError("Couldn't find the app launcher")
-        with open(path, 'r', encoding='UTF-8') as launcher:
-            contents = launcher.read()
-            if 'app.asar' not in contents:
-                print(
-                    f' ...patching app launcher')
-                subprocess.call(
-                    ['sed', '-i', r's/electron6\ app/electron6\ app\.asar/',
-                     path])
+        pathlist = ['/usr/bin/notion-app', '/usr/bin/notion', '/opt/notion-app/notion-app']
+        # get all the possible paths where the launcher may be located
+        for path in pathlist:
+            if os.path.exists(path):
+                with open(path, 'r', encoding='UTF-8') as launcher:
+                    contents = launcher.read()
+                    if 'app.asar' not in contents:
+                        print(f' ...patching app launcher in {path}')
+                        subprocess.call(['sed', '-i', r's/electron6\ app/electron6\ app\.asar/', path])
 
     print(f'\n{bold}>>> SUCCESSFULLY CLEANED <<<{normal}')
 

--- a/cleaner.py
+++ b/cleaner.py
@@ -56,8 +56,8 @@ try:
             f' * {os.path.join(filepath, "app.asar.bak")} was not found: step skipped.')
 
     if sys.platform == 'linux' and 'microsoft' not in platform.uname()[3].lower():
-        pathlist = ['/usr/bin/notion-app', '/usr/bin/notion', '/opt/notion-app/notion-app']
-        # get all the possible paths where the launcher may be located
+        pathlist = ('/usr/bin/notion-app', '/usr/bin/notion', '/opt/notion-app/notion-app')
+        # check all the possible paths where the launcher may be located
         for path in pathlist:
             if os.path.exists(path):
                 with open(path, 'r', encoding='UTF-8') as launcher:

--- a/customiser.py
+++ b/customiser.py
@@ -224,15 +224,12 @@ try:
             f' * {os.path.join(filepath, "app", "main", "main.js")} was not found: step skipped.')
 
     if sys.platform == 'linux' and 'microsoft' not in platform.uname()[3].lower():
-        def patch(dest):
-            print(f' ...patching app launcher in {path}')
-            subprocess.call(['sed', '-i', r's/electron6\ app\.asar/electron6\ app/', dest])
-
-        pathlist = ['/usr/bin/notion-app', '/usr/bin/notion', '/opt/notion-app/notion-app']
+        pathlist = ('/usr/bin/notion-app', '/usr/bin/notion', '/opt/notion-app/notion-app')
         # check all the paths where the launcher may be located
         for path in pathlist:
             if os.path.exists(path):
-                patch(path)
+                print(f' ...patching app launcher in {path}')
+                subprocess.call(['sed', '-i', r's/electron6\ app\.asar/electron6\ app/', path])
 
     print('\n>>> SUCCESSFULLY CUSTOMISED <<<')
 

--- a/customiser.py
+++ b/customiser.py
@@ -226,9 +226,17 @@ try:
     if sys.platform == 'linux' and 'microsoft' not in platform.uname()[3].lower():
         print(
             f' ...patching app launcher')
+        s = ''
+        if os.path.exists('/opt/notion-app/notion-app'):
+            s = '/opt/notion-app/notion-app'
+        elif os.path.exists('/usr/bin/notion-app'):
+            s = '/usr/bin/notion-app'
+        elif os.path.exists('/usr/bin/notion'):
+            s = '/usr/bin/notion'
+        else:
+            raise ValueError("Couldn't find the app launcher")
         subprocess.call(
-            ['sed', '-i', r's/electron\ app\.asar/electron\ app/',
-             '/usr/bin/notion-app' if os.path.exists('/usr/bin/notion-app') else '/usr/bin/notion'])
+            ['sed', '-i', r's/electron6\ app\.asar/electron6\ app/', s])
 
     print('\n>>> SUCCESSFULLY CUSTOMISED <<<')
 

--- a/customiser.py
+++ b/customiser.py
@@ -224,19 +224,15 @@ try:
             f' * {os.path.join(filepath, "app", "main", "main.js")} was not found: step skipped.')
 
     if sys.platform == 'linux' and 'microsoft' not in platform.uname()[3].lower():
-        print(
-            f' ...patching app launcher')
-        s = ''
-        if os.path.exists('/opt/notion-app/notion-app'):
-            s = '/opt/notion-app/notion-app'
-        elif os.path.exists('/usr/bin/notion-app'):
-            s = '/usr/bin/notion-app'
-        elif os.path.exists('/usr/bin/notion'):
-            s = '/usr/bin/notion'
-        else:
-            raise ValueError("Couldn't find the app launcher")
-        subprocess.call(
-            ['sed', '-i', r's/electron6\ app\.asar/electron6\ app/', s])
+        def patch(dest):
+            print(f' ...patching app launcher in {path}')
+            subprocess.call(['sed', '-i', r's/electron6\ app\.asar/electron6\ app/', dest])
+
+        pathlist = ['/usr/bin/notion-app', '/usr/bin/notion', '/opt/notion-app/notion-app']
+        # check all the paths where the launcher may be located
+        for path in pathlist:
+            if os.path.exists(path):
+                patch(path)
 
     print('\n>>> SUCCESSFULLY CUSTOMISED <<<')
 


### PR DESCRIPTION
On AUR, the package notion-app no longer installs the application launcher to /usr/bin. Instead, it creates a .desktop file pointing directly to /opt/notion-app/notion-app. Also, the script no longer uses "electron" as a command for launching, so the line with the command: 
` sed -i 's/electron\ app\.asar/electron\ app/' '/usr/bin/notion-app'`   
had to be changed to ->  
` sed -i 's/electron6\ app\.asar/electron6\ app/' '<path>'  `
I don't know if some distros still install the launcher to /usr/bin so I've added a few lines to check all three locations.
this way, notion is now able to launch. Without the fix, the launcher was not edited and the following error prevented the app from launching:
```
Error launching app
Unable to find Electron app at /opt/notion-app/app.asar

Cannot find module '/opt/notion-app/app.asar'
Require stack:
- /usr/lib/electron6/resources/default_app.asar/main.js
- 
```
P.S. I'm kinda new to python and git too, so excuse me for any problems. 