### PR TITLE
Add replace for other electron app.asar usages

### DIFF
--- a/pkg/apply.js
+++ b/pkg/apply.js
@@ -78,6 +78,8 @@ module.exports = async function ({ overwrite_version, friendly_errors } = {}) {
             bin_script
               .replace('electron app.asar\n', 'electron app\n')
               .replace('electron6 app.asar\n', 'electron6 app\n')
+              .replace('electron app.asar ', 'electron app ')
+              .replace('electron6 app.asar ', 'electron6 app ')
           );
         }
       }

--- a/pkg/remove.js
+++ b/pkg/remove.js
@@ -105,6 +105,8 @@ module.exports = async function ({
             bin_script
               .replace('electron app\n', 'electron app.asar\n')
               .replace('electron6 app\n', 'electron6 app.asar\n')
+              .replace('electron app.asar ', 'electron app ')
+              .replace('electron6 app.asar ', 'electron6 app ')
           );
         }
       }


### PR DESCRIPTION
This fixes apply for the recent [wrapper script update](https://aur.archlinux.org/cgit/aur.git/diff/notion-app?h=notion-app&id=200f7410703b5750a22a73c78be2e1b3ea88031f) for `AUR notion-app`

This is a bit messy but regex might be overkill