### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ then execute `npm i -g notion-enhancer` in the command prompt.
 **macOS**
 
 [install node.js](https://nodejs.org/en/download/) (_a computer restart may be required here_),
-then execute the following lines in the terminal:
+then execute the following lines in the terminal. 
+Omit the first line if using [Node Version Manager](https://github.com/nvm-sh/nvm), as the `node_modules` directory will be located elsewhere and will likely already be owner-writable.
 
 ```
 sudo chmod -R a+wr /usr/local/lib/node_modules


### PR DESCRIPTION
Include NVM caveats in macos install section.  This PR is rather plain and mac-only, but I thought a PR would be nicer than an issue report.  The issue likely applies to other platforms and perhaps you want to have a separate section for NVM or install caveats in general, rather than in-line in the install bit.

To clarify the issue, when I copy/paste the install commands, I get this:
```
chmod: /usr/local/lib/node_modules: No such file or directory
```
because my `node_modules` folder is actually at:
```
~/.nvm/versions/node/v14.2.0/lib/node_modules
```
Feel free to reject the PR and create an issue if that is more appropriate, or I can create the issue if you like.