### PR TITLE
New tweak: Scroll Database Toolbars

### DIFF
--- a/mods/tweaks/mod.js
+++ b/mods/tweaks/mod.js
@@ -66,6 +66,12 @@ module.exports = {
       type: 'toggle',
       value: false,
     },
+    {
+      key: 'scroll_db_toolbars',
+      label: 'scroll database toolbars',
+      type: 'toggle',
+      value: false,
+    },
   ],
   hacks: {
     'renderer/preload.js': (store, __exports) => {
@@ -77,6 +83,7 @@ module.exports = {
           'thicker_bold',
           'spaced_lines',
           'hide_help',
+          'scroll_db_toolbars',
         ]
           .filter((tweak) => store()[tweak])
           .map((tweak) => `[${tweak}]`)

--- a/mods/tweaks/styles.css
+++ b/mods/tweaks/styles.css
@@ -46,3 +46,13 @@
   --theme_light--text-block_line-height: 1.65;
   --theme_light--text-block_margin-top: 0.75em;
 }
+
+[data-tweaks*='[scroll_db_toolbars]'] .notion-frame > .notion-scroller > [style*="overflow: visible;"],
+[data-tweaks*='[scroll_db_toolbars]'] .notion-page-content .notion-collection_view-block > :first-child {
+    overflow-x: auto !important;
+}
+
+[data-tweaks*='[scroll_db_toolbars]'] .notion-frame > .notion-scroller > [style*="overflow: visible;"]::-webkit-scrollbar,
+[data-tweaks*='[scroll_db_toolbars]'] .notion-page-content .notion-collection_view-block > :first-child::-webkit-scrollbar {
+    display: none;
+}


### PR DESCRIPTION
Lets you scroll the toolbar on databases horizontally if part of the toolbar is hidden (scroll horizontally by holding **shift** while scrolling)

![scroll](https://user-images.githubusercontent.com/54142180/97952179-0a1c6180-1dcf-11eb-9344-baf994c1b81e.gif)

![scroll](https://user-images.githubusercontent.com/54142180/97952157-fb35af00-1dce-11eb-8827-54bbb54e011f.gif)
